### PR TITLE
underline links even when they are within, say, em tags

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -175,8 +175,8 @@
 			}
 			// cleaner underlines for links
 			a { text-decoration: none; }
-			p > a,
-			li > a {
+			p a,
+			li a {
 				border-bottom: 1px dotted lighten($link-color, 50);
 				&:hover {
 					border-bottom-style: solid;


### PR DESCRIPTION
In an article, I have a paragraph that is in italics. It has a link in in the middle. The link should be underlined like links in other article paragraphs, but it isn't. This fixes the problem for me, but as I'm not a CSS expert, I won't swear that it's the right choice generally.