### PR TITLE
Centering the off canvas navigation lines within its container

### DIFF
--- a/_sass/_menu-navicons.scss
+++ b/_sass/_menu-navicons.scss
@@ -15,13 +15,16 @@
 
 .nav-lines {
   @include line;
-  position: relative;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   &:before, &:after {
    @include line;
     position: absolute;
     left:0;
     content: '';
-      transform-origin: $button-size/14 center;
+    transform-origin: $button-size/14 center;
   }
   &:before {
     top: $button-size/4;


### PR DESCRIPTION
Before the off canvas navigation lines were pushed down a little bit. This PR centers those links. Images below!

<img width="92" alt="screen shot 2016-10-09 at 12 45 10 am" src="https://cloud.githubusercontent.com/assets/1226984/19216586/3d80896a-8dba-11e6-88b4-1365c42ba24b.png">
<img width="113" alt="screen shot 2016-10-09 at 12 45 16 am" src="https://cloud.githubusercontent.com/assets/1226984/19216587/3d8ea734-8dba-11e6-8274-dc787ffcd944.png">
