### PR TITLE
Exclude 'vendor' dir from being built in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,3 +62,4 @@ exclude:
   - package.json
   - spec
   - tmp
+  - vendor


### PR DESCRIPTION
See #105 

When running `bundle install` without sudo on a fresh checkout, it suggests you put the gems at ./vendor/bundle. Doing this breaks the build. Exclude the vendor directory from being built.